### PR TITLE
Adding bundle step before running jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ submission. Submissions with inappropriate content will not be accepted.
 To submit a site suggestions, [open an issue](https://github.com/trek/beautiful-open/issues/new)
 or create a pull request.
 
-Please check the [`CONTRIBUTING.md` file](./CONTRIBUTING.md) for additional requiremnts.
+Please check the [`CONTRIBUTING.md` file](./CONTRIBUTING.md) for additional requirements.
 
 ### Running the site locally
 ```
 $ gem install jekyll
 $ git clone https://github.com/trek/beautiful-open.git
 $ cd beautiful-open
+$ bundle update
 $ jekyll serve --watch
 ```
 


### PR DESCRIPTION
To ensure all dependencies of jekyll are installed in local machine, we have to run bundle.

I used `bundle update` instead of `bundle install` to ensure latest version of gems.
Here in my machine, `bundle install` installed safe_yaml v1.0.3, which [is buggy](https://github.com/dtao/safe_yaml/issues/73) and failed to run `jekyll serve`. In the other hand, running `bundle update` installed safe_yaml v1.0.4 and everything went well.