### PR TITLE
GraphQL (Fixed)

### DIFF
--- a/_posts/xxxx-xx-xx-graphql.md
+++ b/_posts/xxxx-xx-xx-graphql.md
@@ -1,7 +1,7 @@
-+---
- +layout: post
- +title: "GraphQL"
- +slug: graphql
- +source: http://graphql.org/
- +image: graphql.png
- +---
+---
+layout: post
+title: "GraphQL"
+slug: graphql
+source: http://graphql.org/
+image: graphql.png
+---


### PR DESCRIPTION
Adds [GraphQL](http://graphql.org/) to the beautiful open directory.

This fixes the formatting issue from #451. The markdown should no longer be in `diff` format.