### PR TITLE
Bump ruby versions

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,1 +1,1 @@
-ruby-2.0.0-p353@github-pages
+2.6.2


### PR DESCRIPTION
Trying to shift to Netlify from github pages and the current ruby version won't build on their machines.

Trying the suggested 2.6.2