### PR TITLE
Only emit <img /> tag when image is defined

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,6 +5,6 @@ layout: default
 <h2>{{ page.title }}</h2>
 
 <div class="post">
-  <img src="/screenshots/{{page.image}}">
+  {% if page.image %}<img src="/screenshots/{{page.image}}">{% endif %}
   {{ content }}
 </div>


### PR DESCRIPTION
This PR updates the `page` layout to only emit the `<img />` tag when `page.image` is defined.

The goal is to remove this broken image from the about page:
![image](https://user-images.githubusercontent.com/88163/73967699-3d2bd600-48cd-11ea-8c1e-ed3f0db05404.png)
